### PR TITLE
Add swagger documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,37 +7,7 @@ Before souffle              |  After souffle (by album)
 
 ### REST API
 
-##### ```/refreshtoken``` POST
-* Obtain a spotify refresh token and access token given a valid spotify authorization code
-* Request
-    * Headers:
-        * ```Authorization: Bearer {AUTHORIZATION_CODE}```
-* Response (200)
-    * Body (application/json)
-        * ```accessToken```: spotify access token
-        * ```refreshToken```: spotify refresh token
-
-##### ```/accesstoken``` POST
-* Obtain a fresh spotify access token given a valid spotify refreshtoken
-* Request
-    * Headers:
-        * ```Authorization: Bearer {REFRESH_TOKEN}```
-* Response (200)
-    * Body (application/json)
-        * ```accessToken```: spotify access token
-
-##### ```/souffle``` POST
-* Create a souffle'd playlist from an original playlist in which each track on the souffle'd playlist is swapped with another song on the same album or by the same artist.
-* Request
-    * Headers:
-        * ```Authorization: Bearer {ACCESS_TOKEN}```
-    * Body (application/x-www-form-urlencoded)
-        * ```playlistUri```: uri of the playlist to souffle
-        * ```userId```: id of current user under whose account souffled playlist will be created
-        * ```shuffleBy```: type of collection to shuffle by (```artist``` or ```album```)
-* Response (201)
-    * Headers:
-        * ```Location: {SOUFFLED_PLAYLIST_URI}```
+Check out the API documentation on [swagger](https://app.swaggerhub.com/apis/zhammer/playlist-souffle/1.0.0-oas3).
 
 ### Setting up virtual environment
 ```bash
@@ -47,7 +17,7 @@ virtualenv venv --python=python3
 # Enter venv
 source venv/bin/activate
 
-# Install 
+# Install
 pip install -r requirements.txt
 ```
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,0 +1,147 @@
+openapi: 3.0.0
+servers:
+  - url: 'https://wumxvuo5nb.execute-api.us-east-1.amazonaws.com/dev'
+info:
+  description: >
+    Souffle up your playlists, swapping out each track for another track by the
+    same artist or on the same album.
+  version: "1.0.0-oas3"
+  title: Playlist Souffle
+  contact:
+    email: zach.the.hammer@gmail.com
+  license:
+    name: MIT License
+    url: 'https://opensource.org/licenses/MIT'
+tags:
+  - name: Authorization
+    description: Endpoints for Playlist Souffle\'s Spotify authorization flow.
+  - name: Use cases
+    description: Endpoints for Playlist Souffle\'s use cases.
+paths:
+  /refreshtoken:
+    post:
+      tags:
+        - Authorization
+      summary: Get a spotify refreshtoken and accesstoken given an authorization code.
+      security:
+        - authorizationCode: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                redirectUri:
+                  type: string
+                  description: >
+                    `redirectUri` used in `accounts.spotify.com/authorize` endpoint when fetching `authorizationCode`.
+              example:
+                redirectUri: https://127.0.0.1:8100
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accesstoken:
+                    type: string
+                    description: Access token for the spotify web api
+        '400':
+          $ref: '#/components/responses/UnauthorizedError'
+  /accesstoken:
+    post:
+      tags:
+        - Authorization
+      summary: Get a spotify accesstoken given a valid refreshtoken.
+      security:
+        - refreshToken: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  refreshtoken:
+                    type: string
+                    description: Refresh token for use with the `/accesstoken` endpoint.
+                  accesstoken:
+                    type: string
+                    description: Access token for the spotify web api
+        '400':
+          $ref: '#/components/responses/UnauthorizedError'
+  /souffle:
+    post:
+      tags:
+      - Use cases
+      summary: >
+        Souffle a playlist. The generated playlist will be created on
+        the current user's account.
+      security:
+        - accessToken: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                playlistUri:
+                  type: string
+                  description: Uri of the playlist to be souffled.
+                userId:
+                  type: string
+                  description: >
+                    Id of the current user on whose account the souffle
+                    playlist will be created.
+                shuffleBy:
+                  type: string
+                  description: Type of collection to shuffle by.
+                  enum: [artist, album]
+              example:
+                playlistUri: spotify:user:zachthehammer:playlist:5u1XuTMnpZqhAfkYob8X6U
+                userId: zachthehammer
+                shuffleBy: album
+      responses:
+        '201':
+          description: Created
+          headers:
+            Location:
+              schema:
+                type: string
+                description: Uri of souffled playlist.
+        '400':
+          $ref: '#/components/responses/UnauthorizedError'
+
+
+components:
+  responses:
+    UnauthorizedError:
+      description: Bearer token is missing or invalid.
+  securitySchemes:
+    authorizationCode:
+      description: >
+        Obtain an authorization code by visiting the spotify [/authorize](https://accounts.spotify.com/authorize?client_id=b231329aba1a4c539375436a267db917&response_type=code&redirect_uri=https://127.0.0.1:8100&scope=playlist-read-private%20playlist-modify-private%20playlist-modify-public) page. Browser will redirect to an unreachable url `https://127.0.0.1:8100/?code={AUTHORIZATION_CODE}` from which the `AUTHORIZATION_CODE` can be extracted. An authorization code
+        can only be used once as a Bearer token to the `/refreshtoken` endpoint.
+      type: http
+      scheme: bearer
+    refreshToken:
+      description: >
+        A Spotify refreshtoken that can be used to fetch a fresh accesstoken.
+        (Obtained via the `/refreshtoken` endpoint.)
+      type: http
+      scheme: bearer
+    accessToken:
+      description: >
+        A Spotify accesstoken used as a Bearer token for all requests to the
+        Spotify and Playlist Souffle APIs. (Obtained initially via the
+        `/refreshtoken` endpoint and refreshed via the `/accesstoken` endpoint.)
+      type: http
+      scheme: bearer
+externalDocs:
+  description: Visit the github page
+  url: 'https://github.com/zhammer/playlist-souffle'

--- a/swagger.yml
+++ b/swagger.yml
@@ -5,6 +5,11 @@ info:
   description: >
     Souffle up your playlists, swapping out each track for another track by the
     same artist or on the same album.
+
+
+    Instructions for obtaining an `accesstoken` to the Playlist Souffle use case endpoints can be found
+    in the Authorize popout. For more information about Spotify's Authorization Code Flow,
+    see the [official documentation](https://beta.developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow).
   version: "1.0.0-oas3"
   title: Playlist Souffle
   contact:
@@ -14,9 +19,7 @@ info:
     url: 'https://opensource.org/licenses/MIT'
 tags:
   - name: Authorization
-    description: Endpoints for Playlist Souffle\'s Spotify authorization flow.
   - name: Use cases
-    description: Endpoints for Playlist Souffle\'s use cases.
 paths:
   /refreshtoken:
     post:
@@ -49,7 +52,7 @@ paths:
                   accesstoken:
                     type: string
                     description: Access token for the spotify web api
-        '400':
+        '401':
           $ref: '#/components/responses/UnauthorizedError'
   /accesstoken:
     post:
@@ -72,7 +75,7 @@ paths:
                   accesstoken:
                     type: string
                     description: Access token for the spotify web api
-        '400':
+        '401':
           $ref: '#/components/responses/UnauthorizedError'
   /souffle:
     post:
@@ -114,7 +117,7 @@ paths:
               schema:
                 type: string
                 description: Uri of souffled playlist.
-        '400':
+        '401':
           $ref: '#/components/responses/UnauthorizedError'
 
 
@@ -125,21 +128,30 @@ components:
   securitySchemes:
     authorizationCode:
       description: >
-        Obtain an authorization code by visiting the spotify [/authorize](https://accounts.spotify.com/authorize?client_id=b231329aba1a4c539375436a267db917&response_type=code&redirect_uri=https://127.0.0.1:8100&scope=playlist-read-private%20playlist-modify-private%20playlist-modify-public) page. Browser will redirect to an unreachable url `https://127.0.0.1:8100/?code={AUTHORIZATION_CODE}` from which the `AUTHORIZATION_CODE` can be extracted. An authorization code
-        can only be used once as a Bearer token to the `/refreshtoken` endpoint.
+        A Spotify authorization code that can be exchanged for a refresh/access token.
+
+
+        Obtain an authorization code by visiting the [Spotify Accounts](https://accounts.spotify.com/authorize?client_id=b231329aba1a4c539375436a267db917&response_type=code&redirect_uri=https://127.0.0.1:8100&scope=playlist-read-private%20playlist-modify-private%20playlist-modify-public) page.
+        The browser will redirect to an unreachable url `https://127.0.0.1:8100/?code={AUTHORIZATION_CODE}` from which the `AUTHORIZATION_CODE` can be extracted.
+        An authorization code can only be used once as a Bearer token to the `/refreshtoken` endpoint.
       type: http
       scheme: bearer
     refreshToken:
       description: >
-        A Spotify refreshtoken that can be used to fetch a fresh accesstoken.
-        (Obtained via the `/refreshtoken` endpoint.)
+        A Spotify refreshtoken that can be used to fetch a fresh accesstoken via the `/accesstoken` endpoint.
+
+
+        Obtain a refreshtoken via the `/refreshtoken` endpoint.
       type: http
       scheme: bearer
     accessToken:
       description: >
         A Spotify accesstoken used as a Bearer token for all requests to the
-        Spotify and Playlist Souffle APIs. (Obtained initially via the
-        `/refreshtoken` endpoint and refreshed via the `/accesstoken` endpoint.)
+        Spotify and Playlist Souffle APIs.
+
+
+        Obtain an accesstoken initially via the `/refreshtoken` endpoint. Obtain a fresh
+        accesstoken via the `/accesstoken` endpoint.
       type: http
       scheme: bearer
 externalDocs:

--- a/swagger.yml
+++ b/swagger.yml
@@ -49,6 +49,9 @@ paths:
               schema:
                 type: object
                 properties:
+                  refreshtoken:
+                    type: string
+                    description: Refresh token for use with the `/accesstoken` endpoint.
                   accesstoken:
                     type: string
                     description: Access token for the spotify web api
@@ -69,9 +72,6 @@ paths:
               schema:
                 type: object
                 properties:
-                  refreshtoken:
-                    type: string
-                    description: Refresh token for use with the `/accesstoken` endpoint.
                   accesstoken:
                     type: string
                     description: Access token for the spotify web api
@@ -114,9 +114,9 @@ paths:
           description: Created
           headers:
             Location:
+              description: Uri of souffled playlist.
               schema:
                 type: string
-                description: Uri of souffled playlist.
         '401':
           $ref: '#/components/responses/UnauthorizedError'
 


### PR DESCRIPTION
Check out the documentation at https://app.swaggerhub.com/apis/zhammer/playlist-souffle/1.0.0-oas3. Very new to this. Let me know what your experience working through the interactive api is like.

One great part is the persisting, documented, separated Bearer tokens for each endpoint's authorization.